### PR TITLE
Loosened inst. format, changed sync behavior

### DIFF
--- a/Functions/get_ext_data.m
+++ b/Functions/get_ext_data.m
@@ -14,26 +14,168 @@ function ext_data = get_ext_data(file_path)
     % Methodology
     %     1. Loads data from file path
     %     2. Assigns standardized variable names based on data columns
-    %     3. Outputs loaded data
+    %     3. Linearly interpolates over any missing data indexes
+    %     4. Outputs loaded data
     %
     % NOTE: Funtions assumes a file format and data units.
 
 
     % Load Data:
-    ext_data = readtable(file_path,'NumHeaderLines',2);
+    ext_data = readtable(file_path,'NumHeaderLines',2,"VariableNamesLine",2,"VariableUnitsLine",1);
 
     % Format variable names, assuming one of two output formats:
 
     sz = size(ext_data);
-
-    if sz(2) == 5
-        ext_data.Properties.VariableNames = ["Index","ΔL/L0","ΔL","L1","L0"];
-        ext_data.Properties.VariableUnits = ["1","1","mm","mm","mm"];
-    elseif sz(2) == 2
-        ext_data.Properties.VariableNames = ["Index","ΔL"];
-        ext_data.Properties.VariableUnits = ["1","mm"];
-    else
-        error("Extensometer data load failed: input table doesn't have the expected size (nx5 or nx2)")
+    
+    % Check for multiple extensometer outputs
+    if sz(2) ~= 5 && sz(2) ~=2 % indicates more than one extensometer output
+        choice = questdlg("Load more than one extensometer?","Multiple E's Detected","No","Yes","No");
+        % find start indices of each output extensometer
+        r1 = string(ext_data.Properties.VariableUnits);
+        n = 0;
+        for i = 1:length(r1)
+            n = n + ~strcmp(r1(i),"");
+        end
+        idx = zeros(1,n);
+        c = 1;
+        for i = 1:length(r1)
+            if ~strcmp(r1(i),"")
+                idx(c) = i;
+                c = c + 1;
+            end
+        end
+    else % there is only one extensometer, proceed with extraction:
+        choice = "Skip";
+        if sz(2) == 5
+            ext_data.Properties.VariableNames = ["Index","ΔL/L0","ΔL","L1","L0"];
+            ext_data.Properties.VariableUnits = ["1","1","mm","mm","mm"];
+        elseif sz(2) == 2
+            ext_data.Properties.VariableNames = ["Index","ΔL"];
+            ext_data.Properties.VariableUnits = ["1","mm"];
+        else
+            error("Extensometer data load failed: input table doesn't have the expected size (nx5 or nx2)")
+        end
     end
+
+    switch choice
+        case "Yes"
+            fprintf("Loading data for %d extensometers\n",c)
+            temp = ext_data;
+            
+            % Extract the first extensometer, with the "Index" column
+            d = temp(:,idx(1):idx(2)-1);
+            szd = size(d);
+            if szd(2) == 5
+                d.Properties.VariableNames = ["Index","ΔL/L0_0","ΔL_0","L1_0","L0_0"];
+                d.Properties.VariableUnits = ["1","1","mm","mm","mm"];
+            elseif szd(2) == 2
+                d.Properties.VariableNames = ["Index","ΔL_0"];
+                d.Properties.VariableUnits = ["1","mm"];
+            end
+            Index = d.Index;
+            ext_data = d;
+
+            % Extract the remaining extensometers, without index columns:
+            if n > 2
+                for i = 2:n-1
+                    d = temp(:,idx(i):idx(i+1)-1);
+                    szd = size(d);
+                    if szd(2) == 4
+                        d.Properties.VariableNames = ["ΔL/L0_" + string(i-1),"ΔL_" + string(i-1),"L1_" + string(i-1),"L0_" + string(i-1)];
+                        d.Properties.VariableUnits = ["1","mm","mm","mm"];
+                    elseif szd(2) == 1
+                        d.Properties.VariableNames = "ΔL_" + string(i-1);
+                        d.Properties.VariableUnits = "mm";
+                    else
+                        error("Extensometer data load failed: input table doesn't have the expected size (nx4 or nx1)")
+                    end
+                    d.Index = Index;
+                    ext_data = join(ext_data,d);
+                end
+            end
+
+            % Extract the final extensometer without index column
+            d = temp(:,idx(n):end);
+            szd = size(d);
+            if szd(2) == 4
+                d.Properties.VariableNames = ["ΔL/L0_" + string(n-1),"ΔL_" + string(n-1),"L1_" + string(n-1),"L0_" + string(n-1)];
+                d.Properties.VariableUnits = ["1","mm","mm","mm"];
+            elseif szd(2) == 1
+                d.Properties.VariableNames = "ΔL_" + string(n-1);
+                d.Properties.VariableUnits = "mm";
+            else
+                error("Extensometer data load failed: input table doesn't have the expected size (nx4 or nx1)")
+            end
+            d.Index = Index;
+            ext_data = join(ext_data,d,"LeftKeys","Index","RightKeys","Index");
+
+        case "No" % just take the first one
+            fprintf("Loading data for the 1st of %d extensometers\n",c)
+            c = 1;
+            ext_data = ext_data(:,1:idx(2)-1);
+            sz = size(ext_data);
+            if sz(2) == 5
+                ext_data.Properties.VariableNames = ["Index","ΔL/L0","ΔL","L1","L0"];
+                ext_data.Properties.VariableUnits = ["1","1","mm","mm","mm"];
+            elseif sz(2) == 2
+                ext_data.Properties.VariableNames = ["Index","ΔL"];
+                ext_data.Properties.VariableUnits = ["1","mm"];
+            else
+                error("Extensometer data load failed: input table doesn't have the expected size (nx5 or nx2)")
+            end
+        case "Skip"
+            c = 1;
+    end
+
+    % Check for and interpolate over empty indexes in ext_data
+    
+    % Get number of columns in ext_data:
+    w = width(ext_data);
+    names = ext_data.Properties.VariableNames;
+    for i = 2:w % loop through non 'Index' columns
+
+        % Find nan values
+        tf = isnan(ext_data.(names{i}));
+
+        % determin if nans exist, initialize count
+        if sum(tf)
+            bad = 1;
+            dl = ext_data.(names{i});
+            nan_count = 0;
+        else
+            bad = 0;
+        end
+    
+        % Remove nan values
+        while bad
+            st_idx = find(tf,1); % location of first nan
+            for j = st_idx+1:length(tf)
+                if ~tf(j)
+                    end_idx = j-1; % end of nan string (for more than one in a row)
+                    break
+                end
+            end
+            % linearly interpolate across nan area
+            prec_val = dl(st_idx-1);
+            fol_val = dl(end_idx+1);
+            x = [st_idx-1, end_idx+1];
+            v = [prec_val, fol_val];
+            xq = st_idx:end_idx;
+            vq = interp1(x,v,xq);
+            dl(xq) = vq;
+
+            % recompute nan boolean vector
+            tf = isnan(dl);
+
+            % add to nan count
+            nan_count = nan_count + length(xq);
+            if ~sum(tf) % check for completion of nan removal
+                bad = 0;
+                ext_data.(names{i}) = dl;
+            end
+        end
+    end
+
+    fprintf("Data for %d extensometer(s) loaded successfully\n",c)
 
 end

--- a/Functions/get_inst_data.m
+++ b/Functions/get_inst_data.m
@@ -17,9 +17,136 @@ function inst_data = get_inst_data(file_path)
     %
     % NOTE: Funtions assumes a file format! If header lines are different, this needs to be changed!
 
-    % Load data without formatting warnings:
-    warning off
-    inst_data = readtable(file_path,"NumHeaderLines",8,"VariableNamesLine",7,"VariableUnitsLine",8);
-    warning on
+    % % Load data without formatting warnings:
+    % warning off
+    % % inst_data = readtable(file_path,"NumHeaderLines",8,"VariableNamesLine",7,"VariableUnitsLine",8);
+    % warning on
 
+    % Determine the file format and load the data accordingly
+    fid = fopen(file_path, 'r');
+    if fid == -1
+        error('Could not open file: %s', file_path);
+    end
+    
+    % Read first line to check format
+    firstLine = fgetl(fid);
+    fclose(fid);
+    
+    % Determine file format based on first line content
+    if contains(firstLine, 'Results Table')
+        % Format 1 (Image 1) - has headers and summary before raw data
+        inst_data = loadFormat1(file_path);
+    else
+        % Format 2 (Image 2) - starts directly with column headers
+        inst_data = loadFormat2(file_path);
+    end
+
+    fprintf("Instron data loaded successfully\n")
+
+    function data = loadFormat1(file_path)
+        % Read the file line by line to find the "Raw Data" section
+        fid = fopen(file_path, 'r');
+        lineNum = 0;
+        rawDataLine = 0;
+        
+        while ~feof(fid)
+            line = fgetl(fid);
+            lineNum = lineNum + 1;
+            
+            if contains(line, 'Raw Data')
+                rawDataLine = lineNum;
+                break;
+            end
+        end
+        
+        if rawDataLine == 0
+            fclose(fid);
+            error('Could not find "Raw Data" section in file');
+        end
+        
+        % Read variable names (row after "Raw Data")
+        varNamesLine = fgetl(fid);
+        % Read variable units (next row)
+        varUnitsLine = fgetl(fid);
+        fclose(fid);
+        
+        % Process the variable names and units lines
+        varNames = strsplit(varNamesLine, ',');
+        varUnits = strsplit(varUnitsLine, ',');
+        
+        % Clean up
+        varNames = cellfun(@strtrim, varNames, 'UniformOutput', false);
+        varUnits = cellfun(@strtrim, varUnits, 'UniformOutput', false);
+        
+        % Remove empty names
+        validIdx = ~cellfun(@isempty, varNames);
+        varNames = varNames(validIdx);
+        
+        % Ensure units array is compatible
+        if length(varUnits) >= length(varNames)
+            varUnits = varUnits(validIdx);
+        else
+            % Pad with empty strings if needed
+            varUnits = [varUnits, repmat({''}, 1, length(varNames) - length(varUnits))];
+        end
+        
+        % Make valid MATLAB variable names
+        validVarNames = matlab.lang.makeValidName(varNames);
+        
+        % Read the data
+        opts = detectImportOptions(file_path);
+        opts.DataLines = [rawDataLine + 3, Inf];
+        opts.VariableNames = validVarNames;
+        
+        data = readtable(file_path, opts);
+        
+        % Set units
+        for i = 1:length(validVarNames)
+            data.Properties.VariableUnits{validVarNames{i}} = varUnits{i};
+        end
+    end
+    
+    function data = loadFormat2(file_path)
+        % Read the first few lines to get variable names and units
+        fid = fopen(file_path, 'r');
+        fgetl(fid); % Skip the first line
+        varNamesLine = fgetl(fid); % Read variable names (line 2)
+        varUnitsLine = fgetl(fid); % Read variable units (line 3)
+        fclose(fid);
+        
+        % Process the variable names and units lines
+        varNames = strsplit(varNamesLine, ',');
+        varUnits = strsplit(varUnitsLine, ',');
+        
+        % Clean up
+        varNames = cellfun(@strtrim, varNames, 'UniformOutput', false);
+        varUnits = cellfun(@strtrim, varUnits, 'UniformOutput', false);
+        
+        % Remove empty names
+        validIdx = ~cellfun(@isempty, varNames);
+        varNames = varNames(validIdx);
+        
+        % Ensure units array is compatible
+        if length(varUnits) >= length(varNames)
+            varUnits = varUnits(validIdx);
+        else
+            % Pad with empty strings if needed
+            varUnits = [varUnits, repmat({''}, 1, length(varNames) - length(varUnits))];
+        end
+        
+        % Make valid MATLAB variable names
+        validVarNames = matlab.lang.makeValidName(varNames);
+        
+        % Read the data
+        opts = detectImportOptions(file_path);
+        opts.DataLines = [4, Inf];
+        opts.VariableNames = validVarNames;
+        
+        data = readtable(file_path, opts);
+        
+        % Set units
+        for i = 1:length(validVarNames)
+            data.Properties.VariableUnits{validVarNames{i}} = varUnits{i};
+        end
+    end
 end

--- a/Functions/get_vic_snap.m
+++ b/Functions/get_vic_snap.m
@@ -41,6 +41,7 @@ function vic_snap = get_vic_snap(file_path)
         vic_snap = [data(:,"Count"),data(:,"Time_0_1"),data(:,"PIP")];
     else
         warning("No PIP signal found in '" + file_name + "', skipping")
+        fprintf("VIC-Snap file FAILED to load successfully\n")
         vic_snap = [];
         return
     end
@@ -86,4 +87,5 @@ function vic_snap = get_vic_snap(file_path)
 
     % Output final data table
     vic_snap.PIPCount = PIPCount;
+    fprintf("VIC-Snap file loaded successfully\n")
 end

--- a/Functions/load_data.m
+++ b/Functions/load_data.m
@@ -14,9 +14,8 @@ function synced_force_disp = load_data(target)
     %
     % Methodology
     %     1. Loads VIC-SNAP, VIC-3D Extensometer, and Instron data specified in target
-    %     2. Interpolates over empty indexes in extensometer data
-    %     3. Syncs data using `sync_data` function
-    %     4. Outputs saved data
+    %     2. Syncs data using `sync_data` function
+    %     3. Outputs saved data
     % Dependencies
     %     get_vic_snap.m
     %     get_ext_data.m
@@ -27,39 +26,6 @@ function synced_force_disp = load_data(target)
     vic_snap  = get_vic_snap(target{1});
     ext_data  = get_ext_data(target{2});
     inst_data = get_inst_data(target{3});
-
-    % Check for and interpolate over empty extensometer indexes
-    tf = isnan(ext_data.("ΔL"));
-    if sum(tf)
-        bad = 1;
-        dl = ext_data.("ΔL");
-        nan_count = 0;
-    else
-        bad = 0;
-    end
-
-    while bad
-        st_idx = find(tf,1);
-        for j = st_idx+1:length(tf)
-            if ~tf(j)
-                end_idx = j-1;
-                break
-            end
-        end
-        prec_val = dl(st_idx-1);
-        fol_val = dl(end_idx+1);
-        x = [st_idx-1, end_idx+1];
-        v = [prec_val, fol_val];
-        xq = st_idx:end_idx;
-        vq = interp1(x,v,xq);
-        dl(xq) = vq;
-        tf = isnan(dl);
-        nan_count = nan_count + length(xq);
-        if ~sum(tf)
-            bad = 0;
-            ext_data.("ΔL") = dl;
-        end
-    end
 
     % If vic-snap data is missing, simply output the instron data
     if ~isempty(vic_snap)

--- a/Functions/sync_data.m
+++ b/Functions/sync_data.m
@@ -1,4 +1,4 @@
-function synced_force_disp = sync_data(vic_snap,ext_data,inst_data,trim_tf,targ_var,targ_var_name)
+function synced_force_disp = sync_data(vic_snap,ext_data,inst_data,trim_tf)
     % sync_data.m
     %
     % Francisco Lopez Jimenez Lab, AMReC
@@ -10,20 +10,17 @@ function synced_force_disp = sync_data(vic_snap,ext_data,inst_data,trim_tf,targ_
     %     ext_data      - Table containing extensometer data with fields 'Index' and target variable (e.g., 'ΔL')
     %     inst_data     - Table containing Instron data with fields 'PIPCount', 'Time', and 'Force'
     %     trim_tf       - Boolean flag to trim data outside the Instron test period (default: true)
-    %     targ_var      - Name of the target variable in ext_data (default: "ΔL")
-    %     targ_var_name - Name of the target variable for output table (default: 'Displacement')
     %
     % Outputs
     %     synced_force_disp - Table containing synchronized data with fields 'Index', target variable, 'Force', and 'Time'
     %
     % Methodology
-    %     1. Ensure trim_tf, targ_var, and targ_var_name have default values if not provided.
-    %     2. Convert targ_var_name to char array if it is a string.
-    %     3. Truncate vic_snap or ext_data to ensure they have the same length.
-    %     4. Identify match points using PIPCount and adjust vic_snap time to match inst_data time.
-    %     5. Trim vic_snap and ext_data based on trim_tf flag.
-    %     6. Create truncated instron data that matches 1-to-1 with ext_data.
-    %     7. Combine synchronized data into a new table.
+    %     1. Ensure trim_tf, has default value if not provided.
+    %     2. Truncate vic_snap or ext_data to ensure they have the same length.
+    %     3. Identify match points using PIPCount and adjust vic_snap time to match inst_data time.
+    %     4. Trim vic_snap and ext_data based on trim_tf flag.
+    %     5. Create truncated instron data that matches 1-to-1 with ext_data.
+    %     6. Combine synchronized data into a new table.
     %
     % Dependencies
     %     None
@@ -37,20 +34,6 @@ function synced_force_disp = sync_data(vic_snap,ext_data,inst_data,trim_tf,targ_
         % taken in the few seconds before the Instron test started.
         % Similarly, vic-based data after the end of the Instron data
         % is discarded as well.
-    end
-
-    if ~exist("targ_var","var")
-        targ_var = "ΔL";
-        % Default behavior gets and outputs delta L from extensometer
-    end
-    if ~exist("targ_var_name","var")
-        targ_var_name = 'Displacement';
-        % Default behavior gets and outputs delta L from extensometer
-    end
-
-    % Enforce that targ_var_name input is a char array not a string.
-    if isa(targ_var_name,'string')
-        targ_var_name = char(targ_var_name);
     end
 
     % Enforce that vic and ext datas be the same length:
@@ -92,8 +75,8 @@ function synced_force_disp = sync_data(vic_snap,ext_data,inst_data,trim_tf,targ_
         % zero out vic time:
         vic_snap.Time = vic_snap.Time - vic_snap.Time(1);
 
-        % zero out displacement data
-        ext_data.(targ_var) = ext_data.(targ_var) - ext_data.(targ_var)(1);
+        % % zero out displacement data
+        % ext_data.(targ_var) = ext_data.(targ_var) - ext_data.(targ_var)(1);
     end
 
     % create truncated instron data that matches 1to1 w/ ext. data
@@ -138,6 +121,8 @@ function synced_force_disp = sync_data(vic_snap,ext_data,inst_data,trim_tf,targ_
     end
 
     % combine into a new table
-    synced_force_disp = table(ext_data.Index,ext_data.(targ_var),inst_data.Force,vic_snap.Time,'VariableNames',{'Index',targ_var_name,'Force','Time'});
-
+    % synced_force_disp = table(ext_data.Index,ext_data.(targ_var),inst_data.Force,vic_snap.Time,'VariableNames',{'Index',targ_var_name,'Force','Time'});
+    % synced_force_disp = table(ext_data.Index,vic_snap.Time,inst_data.Force,ext_data(:,2:end),'VariableNames',[{'Index','Time','Force'},ext_data.Properties.VariableNames(2:end)]);
+    synced_force_disp = join(table(ext_data.Index,vic_snap.Time,inst_data.Force,'VariableNames',{'Index','Time','Force'}),ext_data,"Keys","Index");
+    fprintf("Data synced successfully")
 end


### PR DESCRIPTION
- Instron file format now accomodates files with or without the summary table at the top.
- There is not longer a "target variable" used in syncing; rather, all fields contained within the VIC-3D extensometer output file are synced and ouput in the final data table. This allows the user to select strain or displacement etc. later.
- The extensometer loading function now accomodates files with multiple extensometers included. User is asked if they wish to load all extensometers; "No" loads just the first, "Yes" loads all of them.
- Extensometer variable names inlcude `_xx` at the end to signify why extensometer they are from. Ex: data from E3, the 4th extensometer in a file, are labeled `_3`.